### PR TITLE
Multi-map support

### DIFF
--- a/astar/api/astar.script_api
+++ b/astar/api/astar.script_api
@@ -6,9 +6,6 @@
       desc: Initial setup. You have to setup the astar before calling any other methods.
       type: function
       parameters:
-        - name: map_id
-          type: string
-          desc: ID of the map
         - name: map_width
           type: number
           desc: Width of your map. This is generally width of your tilemap.
@@ -45,6 +42,9 @@
         - name: map_vflip[optional]
           type: boolean
           desc: Flips the map vertically. This doesn't flip the coordinates. Also you can set it by call `astar.map_vflip()`. Default is `false`
+        - name: map_id[optional]
+          type: number
+          desc: ID of the map. Has to be an integer from 0 to 2^16 - 1. Default is `0`.
       examples:
         - desc: |-
             ```lua
@@ -68,12 +68,12 @@
         Default is `false` = 1
 
       parameters:
-        - name: map_id
-          type: string
-          desc: ID of the map
         - name: toggle
           type: boolean
           desc: true/false
+        - name: map_id[optional]
+          type: number
+          desc: ID of the map. Has to be an integer from 0 to 2^16 - 1. Default is `0`.
 
     - name: set_map
       desc: Set your map data.
@@ -81,12 +81,12 @@
         * Setting new map data reset the current cache.
       type: function
       parameters:
-        - name: map_id
-          type: string
-          desc: ID of the map
         - name: world
           type: table
           desc: Your tilemap data. Keep it simple as much as you can.
+        - name: map_id[optional]
+          type: number
+          desc: ID of the map. Has to be an integer from 0 to 2^16 - 1. Default is `0`.
 
     - name: set_costs
       desc: Set costs for walkable tiles on your `world` table. This table keys determine the walkable area.
@@ -94,20 +94,17 @@
         Table's sum must be the `astar.DIRECTION_FOUR` or `astar.DIRECTION_EIGHT`.
       type: function
       parameters:
-        - name: map_id
-          type: string
-          desc: ID of the map
         - name: costs
           type: table
           desc: Table of costs for directions.
+        - name: map_id[optional]
+          type: number
+          desc: ID of the map. Has to be an integer from 0 to 2^16 - 1. Default is `0`.
 
     - name: solve
       desc: Solves the path.
       type: function
       parameters:
-        - name: map_id
-          type: string
-          desc: ID of the map
         - name: start_x
           type: number
           desc: Start tile X.
@@ -120,6 +117,9 @@
         - name: end_y
           type: number
           desc: End tile Y.
+        - name: map_id[optional]
+          type: number
+          desc: ID of the map. Has to be an integer from 0 to 2^16 - 1. Default is `0`.
       returns:
         - name: result
           type: number
@@ -138,9 +138,6 @@
       desc: Finds the neighbours according to a given cost.
       type: function
       parameters:
-        - name: map_id
-          type: string
-          desc: ID of the map
         - name: start_x
           type: number
           desc: Start tile X.
@@ -150,6 +147,9 @@
         - name: max_cost
           type: number
           desc: Maximum cost for finding neighbours.
+        - name: map_id[optional]
+          type: number
+          desc: ID of the map. Has to be an integer from 0 to 2^16 - 1. Default is `0`.
       returns:
         - name: near_result
           type: number
@@ -165,22 +165,22 @@
       desc: If your state space is huge, occasionally call `astar.reset_cache()` to free unused memory.
       type: function
       parameters:
-        - name: map_id
-          type: string
-          desc: ID of the map
+        - name: map_id[optional]
+          type: number
+          desc: ID of the map. Has to be an integer from 0 to 2^16 - 1. Default is `0`.
     - name: get_at
       desc: Returns the value from the map array by coordinates.
       type: function
       parameters:
-        - name: map_id
-          type: string
-          desc: ID of the map
         - name: x
           type: number
           desc: Tile X.
         - name: y
           type: number
           desc: Tile Y.
+        - name: map_id[optional]
+          type: number
+          desc: ID of the map. Has to be an integer from 0 to 2^16 - 1. Default is `0`.
       returns:
         - name: value
           type: number
@@ -190,9 +190,6 @@
       desc: Set your value to the map array by coordinates.
       type: function
       parameters:
-        - name: map_id
-          type: string
-          desc: ID of the map
         - name: x
           type: number
           desc: Tile X.
@@ -202,6 +199,9 @@
         - name: value
           type: number
           desc: The value to set.
+        - name: map_id[optional]
+          type: number
+          desc: ID of the map. Has to be an integer from 0 to 2^16 - 1. Default is `0`.
 
     - name: SOLVED
       type: number

--- a/astar/api/astar.script_api
+++ b/astar/api/astar.script_api
@@ -2,6 +2,20 @@
   type: table
   desc: A* Path Finding
   members:
+    - name: new_map_id
+      desc: Get a new self-incrementing map_id.
+      type: function
+      returns:
+        - name: map_id
+          type: number
+          desc: ID of a new map.
+    - name: delete_map
+      desc: Delete a map by its ID. This will free the memory used by the map.
+      type: function
+      parameters:
+        - name: map_id
+          type: number
+          desc: ID of the map to delete. Has to be an integer from 0 to 2^16 - 1.
     - name: setup
       desc: Initial setup. You have to setup the astar before calling any other methods.
       type: function

--- a/astar/api/astar.script_api
+++ b/astar/api/astar.script_api
@@ -6,6 +6,9 @@
       desc: Initial setup. You have to setup the astar before calling any other methods.
       type: function
       parameters:
+        - name: map_id
+          type: string
+          desc: ID of the map
         - name: map_width
           type: number
           desc: Width of your map. This is generally width of your tilemap.
@@ -54,7 +57,7 @@
             local cache = true     -- Optional. Default is true
             local flip_map = false -- Optional. Default is false
 
-            astar.setup(map_width, map_height, direction, allocate, typical_adjacent, cache, flip_map)
+            astar.setup("my_map", map_width, map_height, direction, allocate, typical_adjacent, cache, flip_map)
 
             ```
     - name: use_zero
@@ -65,6 +68,9 @@
         Default is `false` = 1
 
       parameters:
+        - name: map_id
+          type: string
+          desc: ID of the map
         - name: toggle
           type: boolean
           desc: true/false
@@ -75,6 +81,9 @@
         * Setting new map data reset the current cache.
       type: function
       parameters:
+        - name: map_id
+          type: string
+          desc: ID of the map
         - name: world
           type: table
           desc: Your tilemap data. Keep it simple as much as you can.
@@ -85,6 +94,9 @@
         Table's sum must be the `astar.DIRECTION_FOUR` or `astar.DIRECTION_EIGHT`.
       type: function
       parameters:
+        - name: map_id
+          type: string
+          desc: ID of the map
         - name: costs
           type: table
           desc: Table of costs for directions.
@@ -93,6 +105,9 @@
       desc: Solves the path.
       type: function
       parameters:
+        - name: map_id
+          type: string
+          desc: ID of the map
         - name: start_x
           type: number
           desc: Start tile X.
@@ -123,6 +138,9 @@
       desc: Finds the neighbours according to a given cost.
       type: function
       parameters:
+        - name: map_id
+          type: string
+          desc: ID of the map
         - name: start_x
           type: number
           desc: Start tile X.
@@ -146,11 +164,17 @@
     - name: reset_cache
       desc: If your state space is huge, occasionally call `astar.reset_cache()` to free unused memory.
       type: function
-
+      parameters:
+        - name: map_id
+          type: string
+          desc: ID of the map
     - name: get_at
       desc: Returns the value from the map array by coordinates.
       type: function
       parameters:
+        - name: map_id
+          type: string
+          desc: ID of the map
         - name: x
           type: number
           desc: Tile X.
@@ -166,6 +190,9 @@
       desc: Set your value to the map array by coordinates.
       type: function
       parameters:
+        - name: map_id
+          type: string
+          desc: ID of the map
         - name: x
           type: number
           desc: Tile X.

--- a/astar/ext.manifest
+++ b/astar/ext.manifest
@@ -3,24 +3,24 @@ name: "astar"
 platforms:
   x86_64-osx:
     context:
-      flags:      ["-std=c++17"]
+      flags:      ["-std=c++11"]
 
   arm64-ios:
     context:
-      flags:      ["-std=c++17"]
+      flags:      ["-std=c++11"]
 
   armv7-ios:
     context:
-      flags:      ["-std=c++17"]
+      flags:      ["-std=c++11"]
 
   x86_64-win32: 
     context:
-      flags:      ["-std=c++17"]
+      flags:      ["-std=c++11"]
 
   js-web : 
     context:
-      flags:      ["-std=c++17","-stdlib=libc++"]
+      flags:      ["-std=c++11","-stdlib=libc++"]
 
   x86_64-linux:
     context:
-      flags:      ["-std=c++17"]
+      flags:      ["-std=c++11"]

--- a/astar/ext.manifest
+++ b/astar/ext.manifest
@@ -3,23 +3,24 @@ name: "astar"
 platforms:
   x86_64-osx:
     context:
-      flags:      ["-std=c++11"]
+      flags:      ["-std=c++17"]
 
   arm64-ios:
     context:
-      flags:      ["-std=c++11"]
+      flags:      ["-std=c++17"]
 
   armv7-ios:
     context:
-      flags:      ["-std=c++11"]
+      flags:      ["-std=c++17"]
 
   x86_64-win32: 
     context:
-      flags:      ["-std=c++11"]
+      flags:      ["-std=c++17"]
 
   js-web : 
     context:
-      flags:      ["-std=c++11","-stdlib=libc++"]
+      flags:      ["-std=c++17","-stdlib=libc++"]
 
-
-      
+  x86_64-linux:
+    context:
+      flags:      ["-std=c++17"]

--- a/astar/include/micropather/micropather.h
+++ b/astar/include/micropather/micropather.h
@@ -62,10 +62,6 @@ typedef unsigned MP_UPTR;
 
 namespace micropather {
 
-// EXTERNS ADDED
-extern float LeastCostEstimate(void *nodeStart, void *nodeEnd);
-extern void AdjacentCost(void *node, MPVector<StateCost> *neighbors);
-
 struct CacheData {
   CacheData()
       : nBytesAllocated(0), nBytesUsed(0), memoryFraction(0), hit(0), miss(0),

--- a/astar/include/pather.h
+++ b/astar/include/pather.h
@@ -3,12 +3,9 @@
 #include "dmsdk/dlib/log.h"
 #include <math.h>
 #include <micropather/micropather.h>
+#include <string_view>
 
 namespace micropather {
-
-extern MPVector<void *> path;
-extern MPVector<StateCost> nears;
-
 struct Position {
   int16_t x;
   int16_t y;
@@ -51,56 +48,83 @@ const int dy[8] = {
     -1  // SE
 };
 
-void Initialize();
+class Map : Graph {
+public:
+  MicroPather *pather;
+  uint8_t result;
+  uint16_t worldWidth, worldHeight, tileCount, worldSize;
+  uint8_t worldDirection = 8;
+  uint8_t typicalAdjacent = 6;
+  uint8_t mapType = GRID_CLASSIC;
 
-void Setup(uint16_t _worldWidth, uint16_t _worldHeight,
-           uint8_t _worldDirection = 8, uint16_t _allocate = 250,
-           uint16_t _typicalAdjacent = 6, bool _cache = true);
+  int *world;
+  float totalCost;
+  bool cache = true;
 
-// Helper Get/Set
-int GetWordDirection();
-int GetWorldSize();
+  Position pathFrom = {0, 0};
+  Position pathTo = {0, 0};
+  MPVector<void *> path;     // extern
+  MPVector<StateCost> nears; // extern
+  Tile *Costs;
 
-int GetPathSize();
-int GetNearsSize();
-float GetTotalCost();
+  // Entities
+  size_t entitiesSize;
+  uint8_t *entities;
+  bool getEntity = false;
+  bool getNearEntities = false;
 
-void SetTileCount(uint16_t _tileCount);
-void SetWorldSize(uint16_t _worldSize);
-void SetPathFrom(int16_t x, int16_t y);
-void SetPathTo(int16_t x, int16_t y);
-void SetPathFromTo(int16_t from_x, int16_t from_y, int16_t to_x, int16_t to_y);
+  void Initialize();
 
-void SetCosts();
-void AddCostTileID(uint16_t id, uint16_t tileID);
-void AddCost(uint16_t id, uint16_t costID, float cost);
-void SetMapType(uint8_t type);
-void SetMap(int *_world); // NOT USING ANYMORE
-void MapVFlip();
-void MapHFlip();
-void PrintMap(uint8_t zero);
-void SetTile(uint16_t id, int tile);
-void SetEntities(uint8_t *_entities, size_t size); // NOT USING ANYMORE
-void SetEntityCount(size_t size);
-void SetEntity(uint8_t id, int16_t entityID);
-void UseEntities(bool toggle);
+  void Setup(uint16_t _worldWidth, uint16_t _worldHeight,
+             uint8_t _worldDirection = 8, uint16_t _allocate = 250,
+             uint16_t _typicalAdjacent = 6, bool _cache = true);
 
-int WorldAt(int16_t x, int16_t y);
-void SetToWorldAt(int16_t x, int16_t y, int value);
-void NodeToXY(void *node, int16_t *x, int16_t *y);
-void *XYToNode(size_t x, size_t y);
-void PushNeighbors(StateCost *nodeCost, MPVector<StateCost> *neighbors,
-                   int16_t *nx, int16_t *ny, unsigned int a, unsigned int b);
+  // Helper Get/Set
+  int GetWordDirection();
+  int GetWorldSize();
 
-float LeastCostEstimate(void *nodeStart, void *nodeEnd);       // extern
-void AdjacentCost(void *node, MPVector<StateCost> *neighbors); // extern
+  int GetPathSize();
+  int GetNearsSize();
+  float GetTotalCost();
 
-int Passable(int16_t nx, int16_t ny);
-int Solve();
-int SolveNear(float maxCost);
-void Clear();
+  void SetTileCount(uint16_t _tileCount);
+  void SetWorldSize(uint16_t _worldSize);
+  void SetPathFrom(int16_t x, int16_t y);
+  void SetPathTo(int16_t x, int16_t y);
+  void SetPathFromTo(int16_t from_x, int16_t from_y, int16_t to_x,
+                     int16_t to_y);
 
-void ResetPath();
-void ResizePath();
+  void SetCosts();
+  void AddCostTileID(uint16_t id, uint16_t tileID);
+  void AddCost(uint16_t id, uint16_t costID, float cost);
+  void SetMapType(uint8_t type);
+  void SetMap(int *_world); // NOT USING ANYMORE
+  void MapVFlip();
+  void MapHFlip();
+  void PrintMap(uint8_t zero);
+  void SetTile(uint16_t id, int tile);
+  void SetEntities(uint8_t *_entities, size_t size); // NOT USING ANYMORE
+  void SetEntityCount(size_t size);
+  void SetEntity(uint8_t id, int16_t entityID);
+  void UseEntities(bool toggle);
 
+  int WorldAt(int16_t x, int16_t y);
+  void SetToWorldAt(int16_t x, int16_t y, int value);
+  void NodeToXY(void *node, int16_t *x, int16_t *y);
+  void *XYToNode(size_t x, size_t y);
+  void PushNeighbors(StateCost *nodeCost, MPVector<StateCost> *neighbors,
+                     int16_t *nx, int16_t *ny, unsigned int a, unsigned int b);
+
+  float LeastCostEstimate(void *nodeStart, void *nodeEnd);
+  void AdjacentCost(void *node, MPVector<StateCost> *neighbors);
+  void PrintStateInfo(void *state);
+
+  int Passable(int16_t nx, int16_t ny);
+  int Solve();
+  int SolveNear(float maxCost);
+  void Clear();
+
+  void ResetPath();
+  void ResizePath();
+};
 } // namespace micropather

--- a/astar/src/astar.cpp
+++ b/astar/src/astar.cpp
@@ -1,4 +1,3 @@
-#include "dmsdk/lua/lua.h"
 #define LIB_NAME "Astar"
 #define MODULE_NAME "astar"
 #define DLIB_LOG_DOMAIN "ASTAR"

--- a/astar/src/astar.cpp
+++ b/astar/src/astar.cpp
@@ -2,11 +2,11 @@
 #define MODULE_NAME "astar"
 #define DLIB_LOG_DOMAIN "ASTAR"
 
+#include <cinttypes>
+#include <cstddef>
+#include <dmsdk/dlib/hashtable.h>
 #include <dmsdk/sdk.h>
-#include <inttypes.h>
 #include <pather.h>
-#include <string_view>
-#include <unordered_map>
 
 struct MapData {
   micropather::Map map;
@@ -18,118 +18,172 @@ struct MapData {
   int16_t pathX, pathY;
 };
 
-std::unordered_map<std::string_view, MapData> maps;
+static const uint16_t defaultMapId = 0;
 
-static void use_zero(std::string_view mapId, bool _zero) {
-  maps.at(mapId).zero = (_zero) ? 0 : 1;
+static dmHashTable16<MapData *> maps;
+
+static void use_zero(MapData *mapData, bool _zero) {
+  mapData->zero = (_zero) ? 0 : 1;
+}
+
+static MapData *get_map(lua_State *L, int nArg) {
+  const uint16_t _mapId = luaL_optinteger(L, nArg, defaultMapId);
+  MapData **mapData = maps.Get(_mapId);
+  if (mapData == NULL) {
+    dmLogError(
+        "Map %" PRIu16
+        " doesn't exist. You have to setup the astar using astar.setup()\n",
+        _mapId);
+    return NULL;
+  }
+  return *mapData;
 }
 
 static int astar_setup(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  uint16_t _worldWidth = luaL_checkint(L, 2);
-  uint16_t _worldHeight = luaL_checkint(L, 3);
-  uint8_t _worldDirection = luaL_checkint(L, 4);
-  uint16_t _allocate = luaL_checkint(L, 5);
-  uint16_t _typicalAdjacent = luaL_checkint(L, 6);
+  uint16_t _worldWidth = luaL_checkint(L, 1);
+  uint16_t _worldHeight = luaL_checkint(L, 2);
+  uint8_t _worldDirection = luaL_checkint(L, 3);
+  uint16_t _allocate = luaL_checkint(L, 4);
+  uint16_t _typicalAdjacent = luaL_checkint(L, 5);
+
   bool _cache = true;
+  if (lua_isboolean(L, 6)) {
+    _cache = lua_toboolean(L, 6);
+  }
 
+  bool _useZero = false;
   if (lua_isboolean(L, 7)) {
-    _cache = lua_toboolean(L, 7);
+    _useZero = lua_toboolean(L, 7);
   }
 
-  auto [it, _] = maps.try_emplace(_mapId);
-  auto &map_data = it->second;
-
+  bool _mapVFlip = false;
   if (lua_isboolean(L, 8)) {
-    use_zero(_mapId, lua_toboolean(L, 8));
+    bool _mapVFlip = lua_toboolean(L, 8);
   }
 
-  if (lua_isboolean(L, 9)) {
-    map_data.mapVFlip = lua_toboolean(L, 9);
+  uint16_t _mapId = luaL_optinteger(L, 9, defaultMapId);
+  MapData **mapDataPtr = maps.Get(_mapId);
+  MapData *mapData;
+  if (mapDataPtr == NULL) {
+    if (maps.Full()) {
+      maps.OffsetCapacity(maps.Capacity() * 2);
+    }
+    mapData = new MapData();
+    maps.Put(_mapId, mapData);
+  } else {
+    mapData = *mapDataPtr;
   }
 
-  map_data.map.Setup(_worldWidth, _worldHeight, _worldDirection, _allocate,
+  mapData->mapVFlip = _mapVFlip;
+
+  use_zero(mapData, _useZero);
+
+  mapData->map.Setup(_worldWidth, _worldHeight, _worldDirection, _allocate,
                      _typicalAdjacent, _cache);
 
   return 0;
 }
 
 static int astar_map_vflip(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  maps.at(_mapId).map.MapVFlip();
+  MapData *mapData = get_map(L, 1);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->map.MapVFlip();
   return 0;
 }
 
 static int astar_map_hflip(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  maps.at(_mapId).map.MapHFlip();
+  MapData *mapData = get_map(L, 1);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->map.MapHFlip();
   return 0;
 }
 
 static int astar_set_map_type(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  maps.at(_mapId).map.SetMapType(luaL_checkint(L, 2));
+  uint8_t _mapType = luaL_checkint(L, 1);
+  MapData *mapData = get_map(L, 2);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->map.SetMapType(_mapType);
   return 0;
 }
 
 static int astar_set_map(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  auto &mapData = maps.at(_mapId);
-  luaL_checktype(L, 2, LUA_TTABLE);
+  luaL_checktype(L, 1, LUA_TTABLE);
+  MapData *mapData = get_map(L, 2);
+  if (mapData == NULL) {
+    return 0;
+  }
 
-  for (int i = 0; i < mapData.map.GetWorldSize(); i++) {
+  for (int i = 0; i < mapData->map.GetWorldSize(); i++) {
     lua_pushinteger(L, i + 1);
-    lua_gettable(L, -2);
+    lua_gettable(L, 1);
     if (lua_isnumber(L, -1)) {
-      mapData.map.SetTile(i, lua_tointeger(L, -1));
+      mapData->map.SetTile(i, lua_tointeger(L, -1));
     }
     lua_pop(L, 1);
   }
 
-  if (mapData.mapVFlip) {
-    mapData.map.MapVFlip();
+  if (mapData->mapVFlip) {
+    mapData->map.MapVFlip();
   }
 
   return 0;
 }
 
 static int astar_print_map(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  auto &map_data = maps.at(_mapId);
-  maps.at(_mapId).map.PrintMap(map_data.zero);
+  MapData *mapData = get_map(L, 1);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->map.PrintMap(mapData->zero);
   return 0;
 }
 
 static int astar_use_entities(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  maps.at(_mapId).map.UseEntities(lua_toboolean(L, 2));
+  bool _useEntities = lua_toboolean(L, 1);
+  MapData *mapData = get_map(L, 2);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->map.UseEntities(_useEntities);
   return 0;
 }
 
 static int astar_use_zero(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  bool _zero = lua_toboolean(L, 2);
-  use_zero(_mapId, _zero);
+  bool _zero = lua_toboolean(L, 1);
+  MapData *mapData = get_map(L, 2);
+  if (mapData == NULL) {
+    return 0;
+  }
+  use_zero(mapData, _zero);
   return 0;
 }
 
 static int astar_set_entities(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  auto &mapData = maps.at(_mapId);
-  luaL_checktype(L, 2, LUA_TTABLE);
+  luaL_checktype(L, 1, LUA_TTABLE);
 
-  size_t size = lua_objlen(L, 2);
+  size_t size = lua_objlen(L, 1);
   if (size == 0) {
     dmLogError("Entities table can not be empty");
   }
 
-  mapData.map.SetEntityCount(size);
+  MapData *mapData = get_map(L, 2);
+  if (mapData == NULL) {
+    return 0;
+  }
+
+  mapData->map.SetEntityCount(size);
 
   for (int i = 0; i < size; i++) {
     lua_pushinteger(L, i + 1);
-    lua_gettable(L, -2);
+    lua_gettable(L, 1);
     if (lua_isnumber(L, -1)) {
-      mapData.map.SetEntity(i, lua_tointeger(L, -1));
+      mapData->map.SetEntity(i, lua_tointeger(L, -1));
     }
     lua_pop(L, 1);
   }
@@ -138,43 +192,46 @@ static int astar_set_entities(lua_State *L) {
 }
 
 static int astar_set_costs(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  auto &mapData = maps.at(_mapId);
-  luaL_checktype(L, 2, LUA_TTABLE);
+  luaL_checktype(L, 1, LUA_TTABLE);
 
-  mapData.map.ResizePath();
-  mapData.map.ResetPath();
+  MapData *mapData = get_map(L, 2);
+  if (mapData == NULL) {
+    return 0;
+  }
+
+  mapData->map.ResizePath();
+  mapData->map.ResetPath();
 
   uint16_t tileCount = 0;
   uint16_t id = 0;
   uint16_t costID = 0;
 
   lua_pushnil(L);
-  while (lua_next(L, 2) != 0) {
+  while (lua_next(L, 1) != 0) {
     tileCount++;
     lua_pop(L, 1);
   }
 
-  mapData.map.SetTileCount(tileCount);
-  mapData.map.SetCosts();
+  mapData->map.SetTileCount(tileCount);
+  mapData->map.SetCosts();
 
   lua_pushnil(L);
-  while (lua_next(L, 2) != 0) {
-    mapData.map.AddCostTileID(id, lua_tointeger(L, -2));
+  while (lua_next(L, 1) != 0) {
+    mapData->map.AddCostTileID(id, lua_tointeger(L, -2));
 
     if (lua_istable(L, -1)) {
       costID = 0;
       lua_pushnil(L);
 
       while (lua_next(L, -2) != 0) {
-        mapData.map.AddCost(id, costID, lua_tonumber(L, -1));
+        mapData->map.AddCost(id, costID, lua_tonumber(L, -1));
         lua_pop(L, 1);
         costID++;
 
-        if (costID > mapData.map.GetWordDirection()) {
+        if (costID > mapData->map.GetWordDirection()) {
           dmLogError("There are more costs than direction. Cost Count: %i, "
                      "Direction: %i",
-                     costID, mapData.map.GetWordDirection());
+                     costID, mapData->map.GetWordDirection());
           return 0;
         }
       }
@@ -187,84 +244,107 @@ static int astar_set_costs(lua_State *L) {
 }
 
 static int astar_reset_cache(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  maps.at(_mapId).map.ResetPath();
+  MapData *mapData = get_map(L, 1);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->map.ResetPath();
   return 0;
 }
 
 static int astar_resize_path(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  maps.at(_mapId).map.ResizePath();
+  MapData *mapData = get_map(L, 1);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->map.ResizePath();
   return 0;
 }
 
 static int astar_reset(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  maps.at(_mapId).map.Clear();
+  MapData *mapData = get_map(L, 1);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->map.Clear();
   return 0;
 }
 
 static int astar_get_at(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  auto &mapData = maps.at(_mapId);
-  mapData.pathX = luaL_checkint(L, 2) - mapData.zero;
-  mapData.pathY = luaL_checkint(L, 3) - mapData.zero;
-  lua_pushinteger(L, mapData.map.WorldAt(mapData.pathX, mapData.pathY));
+  int16_t pathX = luaL_checkint(L, 1);
+  int16_t pathY = luaL_checkint(L, 2);
+  MapData *mapData = get_map(L, 3);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->pathX = pathX - mapData->zero;
+  mapData->pathY = pathY - mapData->zero;
+  lua_pushinteger(L, mapData->map.WorldAt(mapData->pathX, mapData->pathY));
   return 1;
 }
 
 static int astar_set_at(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  auto &mapData = maps.at(_mapId);
-  mapData.pathX = luaL_checkint(L, 2) - mapData.zero;
-  mapData.pathY = luaL_checkint(L, 3) - mapData.zero;
-  mapData.map.SetToWorldAt(mapData.pathX, mapData.pathY, luaL_checkint(L, 4));
+  int16_t pathX = luaL_checkint(L, 1);
+  int16_t pathY = luaL_checkint(L, 2);
+  int value = luaL_checkint(L, 3);
+  MapData *mapData = get_map(L, 4);
+  if (mapData == NULL) {
+    return 0;
+  }
+  mapData->pathX = pathX - mapData->zero;
+  mapData->pathY = pathY - mapData->zero;
+  mapData->map.SetToWorldAt(mapData->pathX, mapData->pathY, value);
   return 0;
 }
 
 static int astar_solve(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  auto &mapData = maps.at(_mapId);
-
   uint8_t i = 3;
 
-  mapData.map.SetPathFromTo(
-      luaL_checkint(L, 2) - mapData.zero, luaL_checkint(L, 3) - mapData.zero,
-      luaL_checkint(L, 4) - mapData.zero, luaL_checkint(L, 5) - mapData.zero);
-
-  mapData.pathSolved = mapData.map.Solve();
-  mapData.pathSize = mapData.map.GetPathSize();
-  mapData.pathTotalCost = mapData.map.GetTotalCost();
-
-  // Early exit if only found itself
-  if (mapData.pathSize == 1) {
-    mapData.pathSolved = micropather::NO_SOLUTION;
-    mapData.pathSize = 0;
+  int16_t fromX = luaL_checkint(L, 1);
+  int16_t fromY = luaL_checkint(L, 2);
+  int16_t toX = luaL_checkint(L, 3);
+  int16_t toY = luaL_checkint(L, 4);
+  MapData *mapData = get_map(L, 5);
+  if (mapData == NULL) {
+    return 0;
   }
 
-  lua_pushinteger(L, mapData.pathSolved);
-  lua_pushinteger(L, mapData.pathSize);
-  lua_pushnumber(L, mapData.pathTotalCost);
+  mapData->map.SetPathFromTo(fromX - mapData->zero, fromY - mapData->zero,
+                             toX - mapData->zero, toY - mapData->zero);
 
-  if (mapData.pathSize > 1) {
+  mapData->pathSolved = mapData->map.Solve();
+  mapData->pathSize = mapData->map.GetPathSize();
+  mapData->pathTotalCost = mapData->map.GetTotalCost();
+
+  // Early exit if only found itself
+  if (mapData->pathSize == 1) {
+    mapData->pathSolved = micropather::NO_SOLUTION;
+    mapData->pathSize = 0;
+  }
+
+  lua_pushinteger(L, mapData->pathSolved);
+  lua_pushinteger(L, mapData->pathSize);
+  lua_pushnumber(L, mapData->pathTotalCost);
+
+  if (mapData->pathSize > 1) {
 
     i++;
-    lua_createtable(L, mapData.pathSize, 0);
+    lua_createtable(L, mapData->pathSize, 0);
     int newTable = lua_gettop(L);
 
-    for (int ii = 0; ii < mapData.pathSize; ii++) {
-      mapData.map.NodeToXY(mapData.map.path[ii], &mapData.pathX,
-                           &mapData.pathY);
+    for (int ii = 0; ii < mapData->pathSize; ii++) {
+      mapData->map.NodeToXY(mapData->map.path[ii], &mapData->pathX,
+                            &mapData->pathY);
 
       lua_createtable(L, 2, 0);
       lua_pushstring(L, "x");
-      lua_pushinteger(L, mapData.pathX + mapData.zero);
+      lua_pushinteger(L, mapData->pathX + mapData->zero);
       lua_settable(L, -3);
       lua_pushstring(L, "y");
-      lua_pushinteger(L, mapData.pathY + mapData.zero);
+      lua_pushinteger(L, mapData->pathY + mapData->zero);
       lua_settable(L, -3);
       lua_pushstring(L, "id");
-      lua_pushinteger(L, mapData.map.WorldAt(mapData.pathX, mapData.pathY));
+      lua_pushinteger(L, mapData->map.WorldAt(mapData->pathX, mapData->pathY));
       lua_settable(L, -3);
 
       lua_rawseti(L, newTable, ii + 1);
@@ -275,49 +355,53 @@ static int astar_solve(lua_State *L) {
 }
 
 static int astar_solve_near(lua_State *L) {
-  std::string_view _mapId = luaL_checkstring(L, 1);
-  auto &mapData = maps.at(_mapId);
-
   uint8_t i = 2;
 
-  mapData.map.SetPathFrom(luaL_checkint(L, 2) - mapData.zero,
-                          luaL_checkint(L, 3) - mapData.zero);
-
-  mapData.pathSolved = mapData.map.SolveNear(luaL_checknumber(L, 4));
-  mapData.pathSize = mapData.map.GetNearsSize();
-
-  // Early exit if only found itself
-  if (mapData.pathSize == 1) {
-    mapData.pathSolved = micropather::NO_SOLUTION;
-    mapData.pathSize = 0;
+  int16_t x = luaL_checkint(L, 1);
+  int16_t y = luaL_checkint(L, 2);
+  float maxCost = luaL_checknumber(L, 3);
+  MapData *mapData = get_map(L, 4);
+  if (mapData == NULL) {
+    return 0;
   }
 
-  lua_pushinteger(L, mapData.pathSolved);
-  lua_pushinteger(L, mapData.pathSize);
+  mapData->map.SetPathFrom(x - mapData->zero, y - mapData->zero);
 
-  if (mapData.pathSize > 1) {
+  mapData->pathSolved = mapData->map.SolveNear(maxCost);
+  mapData->pathSize = mapData->map.GetNearsSize();
+
+  // Early exit if only found itself
+  if (mapData->pathSize == 1) {
+    mapData->pathSolved = micropather::NO_SOLUTION;
+    mapData->pathSize = 0;
+  }
+
+  lua_pushinteger(L, mapData->pathSolved);
+  lua_pushinteger(L, mapData->pathSize);
+
+  if (mapData->pathSize > 1) {
 
     i++;
-    lua_createtable(L, mapData.pathSize, 0);
+    lua_createtable(L, mapData->pathSize, 0);
     int newTable = lua_gettop(L);
 
-    for (int ii = 0; ii < mapData.pathSize; ii++) {
+    for (int ii = 0; ii < mapData->pathSize; ii++) {
 
-      mapData.map.NodeToXY(mapData.map.nears[ii].state, &mapData.pathX,
-                           &mapData.pathY);
+      mapData->map.NodeToXY(mapData->map.nears[ii].state, &mapData->pathX,
+                            &mapData->pathY);
 
       lua_createtable(L, 2, 0);
       lua_pushstring(L, "x");
-      lua_pushinteger(L, mapData.pathX + mapData.zero);
+      lua_pushinteger(L, mapData->pathX + mapData->zero);
       lua_settable(L, -3);
       lua_pushstring(L, "y");
-      lua_pushinteger(L, mapData.pathY + mapData.zero);
+      lua_pushinteger(L, mapData->pathY + mapData->zero);
       lua_settable(L, -3);
       lua_pushstring(L, "cost");
-      lua_pushnumber(L, mapData.map.nears[ii].cost);
+      lua_pushnumber(L, mapData->map.nears[ii].cost);
       lua_settable(L, -3);
       lua_pushstring(L, "id");
-      lua_pushinteger(L, mapData.map.WorldAt(mapData.pathX, mapData.pathY));
+      lua_pushinteger(L, mapData->map.WorldAt(mapData->pathX, mapData->pathY));
       lua_settable(L, -3);
 
       lua_rawseti(L, newTable, ii + 1);
@@ -387,6 +471,22 @@ static void LuaInit(lua_State *L) {
 }
 
 dmExtension::Result AppInitializeAstar(dmExtension::AppParams *params) {
+  maps.SetCapacity(1);
+  return dmExtension::RESULT_OK;
+}
+
+void clearMaps(void *context, const uint16_t *key, MapData **mapDataPtr) {
+  if (mapDataPtr != NULL) {
+    MapData *mapData = *mapDataPtr;
+    mapData->map.Clear();
+    delete mapData;
+    *mapDataPtr = NULL;
+  }
+}
+
+dmExtension::Result AppFinalizeAstar(dmExtension::AppParams *params) {
+  maps.Iterate(&clearMaps, (void *)NULL);
+  maps.Clear();
   return dmExtension::RESULT_OK;
 }
 

--- a/astar/src/astar.cpp
+++ b/astar/src/astar.cpp
@@ -50,7 +50,7 @@ static MapData *get_map(lua_State *L, int nArg) {
   if (mapData == NULL) {
     dmLogError(
         "Map %" PRIu16
-        " doesn't exist. You have to create the map using astar.create_map()\n",
+        " doesn't exist. You have to setup the map using astar.setup()\n",
         _mapId);
     return NULL;
   }

--- a/astar/src/micropather/micropather.cpp
+++ b/astar/src/micropather/micropather.cpp
@@ -118,7 +118,7 @@ void MicroPather::GetNodeNeighbors(PathNode *node,
     // Not in the cache. Either the first time or just didn't fit. We don't know
     // the number of neighbors and need to call back to the client.
     stateCostVec.resize(0);
-    AdjacentCost(node->state, &stateCostVec);
+    graph->AdjacentCost(node->state, &stateCostVec);
 
     pNodeCost->resize(stateCostVec.size());
     node->numAdjacent = stateCostVec.size();
@@ -214,7 +214,7 @@ int MicroPather::Solve(void *startNode, void *endNode, MP_VECTOR<void *> *path,
   ClosedSet closed(graph);
 
   PathNode *newPathNode = pathNodePool.GetPathNode(
-      frame, startNode, 0, LeastCostEstimate(startNode, endNode), 0);
+      frame, startNode, 0, graph->LeastCostEstimate(startNode, endNode), 0);
 
   open.Push(newPathNode);
   stateCostVec.resize(0);
@@ -251,7 +251,7 @@ int MicroPather::Solve(void *startNode, void *endNode, MP_VECTOR<void *> *path,
           if (newCost < child->costFromStart) {
             child->parent = node;
             child->costFromStart = newCost;
-            child->estToGoal = LeastCostEstimate(child->state, endNode);
+            child->estToGoal = graph->LeastCostEstimate(child->state, endNode);
             child->CalcTotalCost();
             if (inOpen) {
               open.Update(child);
@@ -260,7 +260,7 @@ int MicroPather::Solve(void *startNode, void *endNode, MP_VECTOR<void *> *path,
         } else {
           child->parent = node;
           child->costFromStart = newCost;
-          child->estToGoal = LeastCostEstimate(child->state, endNode),
+          child->estToGoal = graph->LeastCostEstimate(child->state, endNode),
           child->CalcTotalCost();
 
           open.Push(child);

--- a/astar/src/pather.cpp
+++ b/astar/src/pather.cpp
@@ -39,7 +39,6 @@ void Map::SetPathFromTo(int16_t from_x, int16_t from_y, int16_t to_x,
 void Map::Setup(uint16_t _worldWidth, uint16_t _worldHeight,
                 uint8_t _worldDirection, uint16_t _allocate,
                 uint16_t _typicalAdjacent, bool _cache) {
-  printf("CALLED CONSTRUCTOR\n");
   if (pather != NULL) {
     Clear();
     pather = NULL;
@@ -49,17 +48,12 @@ void Map::Setup(uint16_t _worldWidth, uint16_t _worldHeight,
   worldHeight = _worldHeight;
   worldDirection = _worldDirection;
 
-  printf("CALLED SETWORLDSIZE\n");
-
   SetWorldSize(worldWidth * worldHeight);
-  printf("CALLED MALLOC\n");
 
   world = (int *)malloc(sizeof(int) * worldSize);
-  printf("CALLED MEMSET\n");
 
   memset(world, 0,
          sizeof(int) * worldSize); // Set all to 0
-  printf("CALLED MICROPATHER\n");
 
   pather = new MicroPather(this, _allocate, _typicalAdjacent, _cache);
 }

--- a/main/main.script
+++ b/main/main.script
@@ -29,15 +29,17 @@ local entities = {
 	1
 }
 
-function init(self)
-	astar.setup(map_width, map_height, direction, allocate, typical_adjacent, cache, use_zero, map_vflip)
-	astar.set_map(world)
-	astar.set_costs(costs)
-	astar.set_entities(entities)
-	astar.use_entities(true)
-	astar.print_map()
+local map_id = "123"
 
-	local status, size, total_cost, path = astar.solve(5, 1, 1, 4)
+function init(self)
+	astar.setup(map_id, map_width, map_height, direction, allocate, typical_adjacent, cache, use_zero, map_vflip)
+	astar.set_map(map_id, world)
+	astar.set_costs(map_id, costs)
+	astar.set_entities(map_id, entities)
+	astar.use_entities(map_id, true)
+	astar.print_map(map_id)
+
+	local status, size, total_cost, path = astar.solve(map_id, 5, 1, 1, 4)
 
 	if status == astar.SOLVED then
 		print("PATH SOLVED")
@@ -53,9 +55,9 @@ function init(self)
 		print("START_END_SAME")
 	end
 
-	astar.use_entities(false)
+	astar.use_entities(map_id, false)
 
-	local near_status, near_size, nears = astar.solve_near(3, 4, 1.0)
+	local near_status, near_size, nears = astar.solve_near(map_id, 3, 4, 1.0)
 
 	if near_status == astar.SOLVED then
 		print("NEAR SOLVED")

--- a/main/main.script
+++ b/main/main.script
@@ -29,17 +29,15 @@ local entities = {
 	1
 }
 
-local map_id = "123"
-
 function init(self)
-	astar.setup(map_id, map_width, map_height, direction, allocate, typical_adjacent, cache, use_zero, map_vflip)
-	astar.set_map(map_id, world)
-	astar.set_costs(map_id, costs)
-	astar.set_entities(map_id, entities)
-	astar.use_entities(map_id, true)
-	astar.print_map(map_id)
+	astar.setup(map_width, map_height, direction, allocate, typical_adjacent, cache, use_zero, map_vflip)
+	astar.set_map(world)
+	astar.set_costs(costs)
+	astar.set_entities(entities)
+	astar.use_entities(true)
+	astar.print_map()
 
-	local status, size, total_cost, path = astar.solve(map_id, 5, 1, 1, 4)
+	local status, size, total_cost, path = astar.solve(5, 1, 1, 4)
 
 	if status == astar.SOLVED then
 		print("PATH SOLVED")
@@ -55,9 +53,9 @@ function init(self)
 		print("START_END_SAME")
 	end
 
-	astar.use_entities(map_id, false)
+	astar.use_entities(false)
 
-	local near_status, near_size, nears = astar.solve_near(map_id, 3, 4, 1.0)
+	local near_status, near_size, nears = astar.solve_near(3, 4, 1.0)
 
 	if near_status == astar.SOLVED then
 		print("NEAR SOLVED")


### PR DESCRIPTION
This PR implements support for solving multiple maps by adding a new optional last parameter `map_id` to all `astar.*` functions and adding two new functions:
- `astar.new_map_id()` - utility function to generate self-incrementing map IDs starting from 0.
- `astar.delete_map(map_id)` - utility function to clean up memory associated with the specified `map_id`.
The changes are meant to be fully backwards compatible.
Closes #7 